### PR TITLE
2.0.0 release - support dynamically loading the right css for your instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ An userscript to load [TangerineUI Redesign for Mastodon's Web UI](https://githu
 
 # Changelog
 
+### Release 2.0.0
+
+![Untitled](https://github.com/Write/TangerineUI-Userscript/assets/541722/e80605da-c301-4381-ac5b-65ddeea2698f)
+
++ ✨ Support Mastodon >= 4.3.0 ✨
++ Dynamically loads the right CSS based on your instance version
++ Loaded CSS is now minified thanks to jsdelivr
+
 ### Release 1.3.0
 + ✨ Full support for Mastodon >= 4.1.6 ✨
 + Mastodon's enhanced their CSP restriction which made the userscript not working on instance above or equals >= 4.1.6

--- a/TangerineUI.user.js
+++ b/TangerineUI.user.js
@@ -3,11 +3,13 @@
 // @namespace   TangerineUI for Mastodon by @nileane
 // @match       https://mamot.fr/*
 // @match       https://mastodon.social/*
+// @match       https://piaille.fr/*
+// @match       https://eldritch.cafe/*
 // @match       https://AddYourInstanceUrlHere.tld/*
 // @downloadURL https://github.com/Write/TangerineUI-Userscript/raw/main/TangerineUI.user.js
 // @homepageURL https://github.com/Write/TangerineUI-Userscript
 // @grant       none
-// @version     1.3.1
+// @version     1.3.3
 // @author      @Write on Github for the UserScript
 // @author      @nileane for TangerineUI's CSS
 // @icon        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACE0lEQVR4AZXOA2xeUQAF4BvNW8xGi7WFY227v81otu0Fs23btq3attunvrN7//bOPMmX98414bFa4edyda12u7te0m8d1UKhRyNVT32idrtcGE6+jdMpBzjtUjOFf2KTZJddchKWsWPR22HprKLATBwnYOM6CfNni+Bjs2d0j02ZKLDOCVZrhx9xGNuT7aY2MAvmdKCjQwXP0UMidm4ToPYMiSKwcmkn+Hqbsd1L7LqWqTZ9M5injyXf4oN7O3HkQCdkGRAEFWdOCNi9vROKAnx8L4Ovt+uaZhCbpn6eTVsPpjBfRkN9F3ivLFfQ0qJ+6SXFCupqv86zvcSWVjPTml4DprhQRm21At7ZgbU1X3tBnoxGegHvlvSa2cSaUjXWklIJhh/Ae2Ge5DuA94JcyfdC3q2plVOJObncYU4qA1NcIPkO4H2soxLjXZW80wNEesDXeVNSqYcY44s1pvhiMDcvt+LB7Tbw/qPrF1rx+F77l25IKh1KjNEFw40xBfhfhpiCs4RFE/JxgDEqR6Xwj5qptZaot/0JjyE867UhPBOcMeJThCH8U6QhLNNgjMj06iMyjfQ/0RSROSQ2Nrc3+TG60I/J+tAPKgWfsI/7NaMe9SXfxBSbO4j8Kdrgdx5d0FuBQrd3zbrgN28Y2quofPK3aILeDtb6v1yt8X/5Suv/qo0Sdf6vijT+r05q/F9Hkl/kM/y+SpUd6mHfAAAAAElFTkSuQmCC
@@ -21,20 +23,33 @@
      *   SETTINGS
      * ---------------- */
 
-    /* Reminder: Purple Variant URL
-     * https://cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI-purple.css
-     */
-    let styleUrl = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI.css'
-    const timeout = 1000;
+    /* Either 'tangerine' or 'purple' */
+    const colorScheme = 'tangerine';
+
 
     /* ----------------
      *   HELPERS
      * ---------------- */
-    const currentPagepath = window.location.pathname;
-    const placeholder = 'TangerineUI 🍊';
-    const log = (str) => console.log("* " + placeholder + " : " + str + " *");
-    const theme = window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-    const isPurple = styleUrl.match('-purple.css') ? true : false;
+    const currentPagepath       = window.location.pathname;
+    const placeholder           = 'TangerineUI 🍊';
+    const log                   = (str) => console.log("* " + placeholder + " : " + str + " *");
+    const theme                 = window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    const timeout               = 1000;
+
+    const tangerineURL          = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI.css'
+    const tangerinePurpleURL    = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI-purple.css'
+
+    const tangerine430URL       = 'https://cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@Mastodon-v4.3.0/TangerineUI.css'
+    const tangerinePurple430URL = 'https://cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@Mastodon-v4.3.0/TangerineUI-purple.css'
+
+    /*
+     * As long as no version is detected, styleUrl is set for version < 4.3.0
+     * */
+    let styleUrl = tangerineURL
+    if (colorScheme == 'purple')
+        styleUrl = tangerinePurpleURL
+
+    const isPurple = colorScheme.includes('purple') ? true : false;
 
     const onElemAvailable = async selector => {
         while (document.querySelector(selector) === null) {
@@ -45,6 +60,7 @@
 
     function createStyleNode(nonce) {
         var node = document.createElement('link');
+        log("Injected theme URI is : " + styleUrl)
         node.href = styleUrl;
         node.nonce = nonce;
         node.rel = 'stylesheet';
@@ -62,6 +78,25 @@
     let timeoutExist = false;
     let mutationStatus = true;
     let nonce;
+
+    /* Version detection */
+    onElemAvailable('script[id^=initial-state]').then((selector) => {
+        const mastodonVersion = JSON.parse(selector.innerText).meta.version
+        log("Mastodon Version Detected is : " + mastodonVersion);
+        if (mastodonVersion.includes('4.3.') || mastodonVersion.includes('4.4.')) {
+            log("Version above or equel 4.3.0 found.")
+            if (isPurple)
+              styleUrl = tangerinePurple430URL
+            else
+              styleUrl = tangerine430URL
+        } else {
+            log("Version below 4.3.0 found.")
+            if (isPurple)
+              styleUrl = tangerinePurpleURL
+            else
+              styleUrl = tangerineURL
+        }
+    });
 
     if (theme == 'light') {
         if (!isPurple)

--- a/TangerineUI.user.js
+++ b/TangerineUI.user.js
@@ -9,7 +9,7 @@
 // @downloadURL https://github.com/Write/TangerineUI-Userscript/raw/main/TangerineUI.user.js
 // @homepageURL https://github.com/Write/TangerineUI-Userscript
 // @grant       none
-// @version     1.3.3
+// @version     2.0.0
 // @author      @Write on Github for the UserScript
 // @author      @nileane for TangerineUI's CSS
 // @icon        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACE0lEQVR4AZXOA2xeUQAF4BvNW8xGi7WFY227v81otu0Fs23btq3attunvrN7//bOPMmX98414bFa4edyda12u7te0m8d1UKhRyNVT32idrtcGE6+jdMpBzjtUjOFf2KTZJddchKWsWPR22HprKLATBwnYOM6CfNni+Bjs2d0j02ZKLDOCVZrhx9xGNuT7aY2MAvmdKCjQwXP0UMidm4ToPYMiSKwcmkn+Hqbsd1L7LqWqTZ9M5injyXf4oN7O3HkQCdkGRAEFWdOCNi9vROKAnx8L4Ovt+uaZhCbpn6eTVsPpjBfRkN9F3ivLFfQ0qJ+6SXFCupqv86zvcSWVjPTml4DprhQRm21At7ZgbU1X3tBnoxGegHvlvSa2cSaUjXWklIJhh/Ae2Ge5DuA94JcyfdC3q2plVOJObncYU4qA1NcIPkO4H2soxLjXZW80wNEesDXeVNSqYcY44s1pvhiMDcvt+LB7Tbw/qPrF1rx+F77l25IKh1KjNEFw40xBfhfhpiCs4RFE/JxgDEqR6Xwj5qptZaot/0JjyE867UhPBOcMeJThCH8U6QhLNNgjMj06iMyjfQ/0RSROSQ2Nrc3+TG60I/J+tAPKgWfsI/7NaMe9SXfxBSbO4j8Kdrgdx5d0FuBQrd3zbrgN28Y2quofPK3aILeDtb6v1yt8X/5Suv/qo0Sdf6vijT+r05q/F9Hkl/kM/y+SpUd6mHfAAAAAElFTkSuQmCC

--- a/TangerineUI.user.js
+++ b/TangerineUI.user.js
@@ -26,6 +26,12 @@
     /* Either 'tangerine' or 'purple' */
     const colorScheme = 'tangerine';
 
+    /* Github tag to use for mastodon instance below 4.3.0 and above or equals 4.3.0https://www.icloud.com/shortcuts/cec0c464458d402b9f53d28bb1da21a1
+    /* To find tags name, go here : https://github.com/nileane/TangerineUI-for-Mastodon/releases
+    /* and look at the tag name in the left sidebar of the release
+     * */
+    const tag_below_4_3_0 = "latest"
+    const tag_above_or_equals_4_3_0 = "v2.0.0-pre3"
 
     /* ----------------
      *   HELPERS
@@ -36,18 +42,18 @@
     const theme                 = window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     const timeout               = 1000;
 
-    const tangerineURL          = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI.css'
-    const tangerinePurpleURL    = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@main/TangerineUI-purple.css'
-
-    const tangerine430URL       = 'https://cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@Mastodon-v4.3.0/TangerineUI.css'
-    const tangerinePurple430URL = 'https://cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@Mastodon-v4.3.0/TangerineUI-purple.css'
+    const tangerine_below_4_3_0             = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@' + tag_below_4_3_0 + '/TangerineUI'
+    const tangerine_above_or_equals_4_3_0   = '//cdn.jsdelivr.net/gh/nileane/TangerineUI-for-Mastodon@' + tag_above_or_equals_4_3_0 + '/TangerineUI'
 
     /*
      * As long as no version is detected, styleUrl is set for version < 4.3.0
      * */
-    let styleUrl = tangerineURL
-    if (colorScheme == 'purple')
-        styleUrl = tangerinePurpleURL
+    let styleUrl = tangerine_below_4_3_0
+    if (colorScheme == 'purple') {
+        styleUrl = tangerine_below_4_3_0 + "-purple.min.css"
+    } else {
+        styleUrl = tangerine_below_4_3_0 + ".min.css"
+    }
 
     const isPurple = colorScheme.includes('purple') ? true : false;
 
@@ -83,18 +89,14 @@
     onElemAvailable('script[id^=initial-state]').then((selector) => {
         const mastodonVersion = JSON.parse(selector.innerText).meta.version
         log("Mastodon Version Detected is : " + mastodonVersion);
-        if (mastodonVersion.includes('4.3.') || mastodonVersion.includes('4.4.')) {
-            log("Version above or equel 4.3.0 found.")
+        if (mastodonVersion.includes('4.3.') || mastodonVersion.includes('4.4.') || mastodonVersion.includes('4.5.')) {
+            log("Version above or equal 4.3.0 found.")
             if (isPurple)
-              styleUrl = tangerinePurple430URL
+              styleUrl = tangerine_above_or_equals_4_3_0 + "-purple.min.css"
             else
-              styleUrl = tangerine430URL
+              styleUrl = tangerine_above_or_equals_4_3_0 + ".min.css"
         } else {
             log("Version below 4.3.0 found.")
-            if (isPurple)
-              styleUrl = tangerinePurpleURL
-            else
-              styleUrl = tangerineURL
         }
     });
 


### PR DESCRIPTION
- support Mastodon >= 4.3.0
- Dynamically loads the right CSS based on your instance version
- Loaded CSS is now minified thanks to jsdelivr